### PR TITLE
Fix `ArgParser` error handling

### DIFF
--- a/src/archetypeai/utils.py
+++ b/src/archetypeai/utils.py
@@ -25,8 +25,8 @@ def pformat(data: dict, prefix: str = "") -> str:
 class ArgParser(argparse.ArgumentParser):
     """Creates a custom arg parser with common ArchetypeAI args."""
 
-    def __init__(self):
-        super().__init__(self)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.add_argument("--api_key", required=True, type=str, help="Your Archetype AI API key")
         self.add_argument("--api_endpoint", default=DEFAULT_ENDPOINT, type=str, help="The target API endpoint")
         self.add_argument("--logging_level", default=logging.INFO, type=str, help="Sets the logging level")

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,39 @@
+import io
+import contextlib
+import pytest
+from archetypeai.utils import ArgParser
+
+
+def test_argparser_missing_required_arg():
+    """
+    Ensures that missing required args are correctly reported
+    """
+    parser = ArgParser()
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr), pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([])
+    assert exc_info.value.code == 2
+    assert "the following arguments are required" in stderr.getvalue()
+
+def test_argparser_supports_argumentParser_arguments():
+    """
+    Ensures that you can pass ArgsParser the same arguments as ArgumentParser supports, and they
+    are handled correctly. Technically, this test only valid 2 of ArguemntParser, but this should
+    be enough to ensure things work as expected since we use `*args` and `**kwargs` to pass the
+    arguments.
+    """
+    # Test an argument by position (the first argument is `prog`, the name of the pogram)
+    parser = ArgParser("MyTestProgram")
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr), pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([])
+    assert exc_info.value.code == 2
+    assert "usage: MyTestProgram" in stderr.getvalue()
+
+    # Test an argument by keyword
+    parser = ArgParser(usage="A custom usage message")
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr), pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([])
+    assert exc_info.value.code == 2
+    assert "usage: A custom usage message" in stderr.getvalue()


### PR DESCRIPTION
The `ArgParser` class extends `argparse.ArgumentParser` but was mistakenly passing `self` to the super `__init__` method. The first positionl argument of `argparse.ArgumentParser` ctor is `prog`, a string. This didn't prevent parsing of valid arguments, if a parsing error happened, then generating the usage message was trying to stringify the parser itself as the program name, which resulted in a recursion error.

This remove passing `self` to `super().__init__()` so proper usage message gets displayed on argument parsing issue. But I suspect the intent of passing `self` to the super class was to "forward" all the arguments that `argparse.ArgumentParser` do support, so this PR forward those arguments (using `*args` and `**kwargs`).